### PR TITLE
Implement a watcher account to keep track of threads

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -61,6 +61,52 @@ export async function validMemberFetch(
 }
 
 /*
+Watcher
+*/
+type WatcherData = {
+  threads: SettingsThreadRef[];
+};
+
+async function watcherProgramAddressGet(
+  program: anchor.Program
+): Promise<[anchor.web3.PublicKey, number]> {
+  return await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from('watcher_account')],
+    program.programId
+  );
+}
+
+export async function watcherCreate(
+  program: anchor.Program,
+  owner?: anchor.web3.PublicKey
+) {
+  const [watcherpk, watcher_nonce] = await watcherProgramAddressGet(program);
+  const tx = await program.rpc.createWatcherAccount(
+    new anchor.BN(watcher_nonce),
+    {
+      accounts: {
+        owner: owner || program.provider.wallet.publicKey,
+        watcherAccount: watcherpk,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      },
+    }
+  );
+  await waitForFinality(program, tx);
+}
+
+export async function watcherThreadsGet(
+  program: anchor.Program
+): Promise<SettingsThreadRef[]> {
+  const [watcherpk] = await watcherProgramAddressGet(program);
+  const watcherDataObject = await program.account.watcherAccount.fetch(
+    watcherpk
+  );
+  const watcherData = watcherDataObject as WatcherData;
+  return watcherData.threads;
+}
+
+/*
 Settings
 */
 
@@ -136,12 +182,7 @@ export async function settingsCreate(
     signers,
     instructions,
   });
-  try {
-    await waitForFinality(program, tx);
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
+  await waitForFinality(program, tx);
 
   return await settingsGet(
     program,
@@ -190,22 +231,28 @@ export async function threadCreate(
   wallet: Wallet_
 ): Promise<ThreadAccount> {
   const kp = anchor.web3.Keypair.generate();
-  const [settingspk, nonce] = await settingsProgramAddressGet(
+  const [settingspk, settings_nonce] = await settingsProgramAddressGet(
     program,
     wallet.publicKey
   );
-  const tx = await program.rpc.createThreadAccount(new anchor.BN(nonce), {
-    accounts: {
-      owner: program.provider.wallet.publicKey,
-      threadAccount: kp.publicKey,
-      settingsAccount: settingspk,
-      rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-    },
-    signers: [kp],
-    instructions: [
-      await program.account.threadAccount.createInstruction(kp, 512),
-    ],
-  });
+  const [watcherpk, watcher_nonce] = await watcherProgramAddressGet(program);
+  const tx = await program.rpc.createThreadAccount(
+    new anchor.BN(settings_nonce),
+    new anchor.BN(watcher_nonce),
+    {
+      accounts: {
+        owner: program.provider.wallet.publicKey,
+        threadAccount: kp.publicKey,
+        settingsAccount: settingspk,
+        watcherAccount: watcherpk,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      },
+      signers: [kp],
+      instructions: [
+        await program.account.threadAccount.createInstruction(kp, 512),
+      ],
+    }
+  );
 
   await waitForFinality(program, tx);
   return await threadGet(program, kp.publicKey);
@@ -565,6 +612,27 @@ Transactions
 */
 
 async function waitForFinality(
+  program: anchor.Program,
+  transactionStr: string,
+  finality: anchor.web3.Finality | undefined = 'confirmed',
+  maxRetries = 10, // try 10 times
+  sleepDuration = 500 // wait 0.5s between tries
+): Promise<anchor.web3.TransactionResponse> {
+  try {
+    return await waitForFinality_inner(
+      program,
+      transactionStr,
+      finality,
+      maxRetries,
+      sleepDuration
+    );
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+async function waitForFinality_inner(
   program: anchor.Program,
   transactionStr: string,
   finality: anchor.web3.Finality | undefined = 'confirmed',

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -4,6 +4,8 @@ import * as anchor from '@project-serum/anchor';
 import assert from 'assert';
 import { PublicKey, Transaction, SystemProgram } from '@solana/web3.js';
 import {
+  watcherCreate,
+  watcherThreadsGet,
   messageCreate,
   addUserToThread,
   threadCreate,
@@ -34,6 +36,12 @@ transferTransaction.add(
     lamports: 1000000000,
   })
 );
+
+describe('test watcher create', () => {
+  it('creates a watcher account', async () => {
+    await watcherCreate(PROGRAM);
+  });
+});
 
 describe('test settings', () => {
   it('creates a settings account for the user', async () => {
@@ -212,5 +220,13 @@ describe('test encrypted messages', () => {
     for (let i = 0; i < n; i++) {
       assert.strictEqual(messages[i].message.text, 'h'.repeat(n - i - 1));
     }
+  });
+});
+
+describe('test watcher', () => {
+  it('watcher can see thread list', async () => {
+    let threads = await watcherThreadsGet(PROGRAM);
+    assert.strictEqual(threads.length, 1);
+    assert.strictEqual(threads[0].key.toString(), threadpk.toString());
   });
 });


### PR DESCRIPTION
Resolves #9. Implementation is basically as simple as possible: watcher account holds list of threads, needs to be created at start of program invocation. 

In the future, `watcherThreadsGet` could be modified to instantiate the `WatcherAccount` on first invocation.

I included a fair amount of unrelated tidying. Could split into separate PRs if we care about that.

We should set up CI for this repository very soon.